### PR TITLE
get_name(): use correct key (login) if no name

### DIFF
--- a/retrieve_contributors.py
+++ b/retrieve_contributors.py
@@ -22,7 +22,7 @@ def get_name(contributor):
 
         return contributor_data["login"]
 
-    return contributor["name"]
+    return contributor["login"]
 
 file_in_repo = sys.argv[1]
 


### PR DESCRIPTION
This code path is probably not actually used, but there is no `name` field in the list of contributors, only `login`.