### PR TITLE
Revert "get_name(): use correct key (login) if no name"

### DIFF
--- a/retrieve_contributors.py
+++ b/retrieve_contributors.py
@@ -22,7 +22,7 @@ def get_name(contributor):
 
         return contributor_data["login"]
 
-    return contributor["login"]
+    return contributor["name"]
 
 file_in_repo = sys.argv[1]
 


### PR DESCRIPTION
Reverts TheLastProject/contributors-to-file-action#2

As much as it made sense to me, it broke CI: https://github.com/CatimaLoyalty/Android/actions/runs/5704211713/job/15457602961

@obfusk fyi