### PR TITLE
pass GITHUB_TOKEN via env instead

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,6 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.token }}
     - ${{ inputs.file_in_repo }}
+  env:
+    GITHUB_TOKEN: ${{ inputs.token }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/sh -l
 
-token="$1"
-file_in_repo="$2"
+file_in_repo="$1"
 
 mkdir -p "$(dirname "$file_in_repo")"
-python3 /retrieve_contributors.py "$token" "$file_in_repo"
+python3 /retrieve_contributors.py "$file_in_repo"

--- a/retrieve_contributors.py
+++ b/retrieve_contributors.py
@@ -29,9 +29,9 @@ def get_name(contributor):
     return contributor["login"]
 
 
-token = sys.argv[1]
-file_in_repo = sys.argv[2]
+file_in_repo = sys.argv[1]
 
+token = os.environ.get("GITHUB_TOKEN") or None
 headers = dict(Authorization=f"token {token}") if token else {}
 
 if token:


### PR DESCRIPTION
Follows up on https://github.com/TheLastProject/contributors-to-file-action/commit/d49f37d8013cda6b9aa4ba86235d7b00d76fc07f#r126952745

This only changes the internals, so users should not notice any difference (unless they run the Python script directly).
Tested using my catima fork, got the exact same result as with your version :)