### PR TITLE
remove unused outputs: from action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,6 @@ inputs:
   file_in_repo:
     description: 'The location of the file in the repository to write to'
     required: true
-outputs:
-  status:
-    description: 'If the file has changed'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
I don't see the script produce any outputs? I don't see `GITHUB_OUTPUT` used anywhere. So this should probably be removed or actually used.

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter